### PR TITLE
feat: wire localization editor basic workflows

### DIFF
--- a/packages/locales-web/components/AppHeader.vue
+++ b/packages/locales-web/components/AppHeader.vue
@@ -50,7 +50,7 @@
 
             <template #content>
               <div class="py-1 min-w-36">
-                <button v-for="lang in availableLanguages.filter(l => l.code !== currentLanguage)" :key="lang.code"
+                <button v-for="lang in languageOptions.filter(l => l.code !== currentLanguage)" :key="lang.code"
                   @click="selectLanguage(lang.code)"
                   class="w-full text-left px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors rounded-sm flex items-center gap-2">
                   <div class="i-carbon-language text-xs opacity-60"></div>
@@ -90,7 +90,7 @@
   </header>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { useSettingsNew } from '~/composables/useSettingsNew'
 import { useTranslationsNew } from '~/composables/useTranslationsNew'
 
@@ -102,10 +102,12 @@ const route = useRoute()
 const isEditingPage = computed(() => route.path === '/editor')
 
 const {
-  languages,
+  availableLanguages,
   currentLanguage,
   hasUnsavedChanges,
   saveAllChanges,
+  selectLanguage: selectLanguageInStore,
+  dialog,
   activeNamespace,
   namespaces
 } = useTranslationsNew()
@@ -117,15 +119,19 @@ const showSaveButton = computed(() => isEditingPage.value && hasUnsavedChanges.v
 const languageSelectorRef = ref()
 
 // 可用语言列表
-const availableLanguages = computed(() => languages.value || [
+const fallbackLanguages = [
   { code: 'zh-CN', name: '简体中文' },
   { code: 'en-US', name: 'English' }
-])
+]
+
+const languageOptions = computed(() =>
+  availableLanguages.value?.length ? availableLanguages.value : fallbackLanguages
+)
 
 // 当前语言信息
 const getCurrentLanguage = computed(() => {
-  return availableLanguages.value.find(lang => lang.code === currentLanguage.value) ||
-    availableLanguages.value[0]
+  const list = languageOptions.value
+  return list.find((lang) => lang.code === currentLanguage.value) || list[0]
 })
 
 // 当前命名空间信息
@@ -172,14 +178,26 @@ function getProgressColor(progress) {
 }
 
 // 选择语言
-function selectLanguage(languageCode) {
-  // TODO: 实现语言切换逻辑
-  console.log('Select language:', languageCode)
-  languageSelectorRef.value?.close()
+async function selectLanguage(languageCode: string) {
+  if (!languageCode || languageCode === currentLanguage.value) {
+    languageSelectorRef.value?.close()
+    return
+  }
+
+  try {
+    const switched = await selectLanguageInStore(languageCode)
+    if (switched) {
+      languageSelectorRef.value?.close()
+    }
+  } catch (error) {
+    console.error('Failed to switch language:', error)
+    if (dialog) {
+      await dialog.alert('切换语言时出现问题，请稍后再试。')
+    }
+  }
 }
 
-// 处理语言选择确认
-function handleLanguageSelect(languageCode) {
-  selectLanguage(languageCode)
+async function handleLanguageSelect(languageCode: string) {
+  await selectLanguage(languageCode)
 }
 </script>

--- a/packages/locales-web/pages/editor.vue
+++ b/packages/locales-web/pages/editor.vue
@@ -25,9 +25,9 @@
         <h3 class="text-sm font-medium text-antfu-text mb-3">
           Current Language
         </h3>
-        <select v-model="currentLanguage"
+        <select :value="currentLanguage" @change="handleLanguageChange"
           class="w-full px-3 py-2 text-sm border border-antfu-border bg-antfu-bg text-antfu-text rounded focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500">
-          <option v-for="lang in languages" :key="lang.code" :value="lang.code">
+          <option v-for="lang in availableLanguages" :key="lang.code" :value="lang.code">
             {{ lang.name }} {{ lang.isBase ? '(Base)' : '' }}
           </option>
         </select>
@@ -110,7 +110,11 @@
             </button>
 
             <!-- 添加键按钮 -->
-            <AddKeyPopover :namespace="activeNamespace" :base-language="currentLanguage" @add-key="handleAddKey" />
+            <AddKeyPopover
+              :namespace="activeNamespace"
+              :base-language="baseLanguage?.name || baseLanguage?.code || 'Base'"
+              @add-key="handleAddKey"
+            />
 
             <!-- 添加语言按钮 -->
             <AddLanguagePopover @add-language="handleAddLanguage" />
@@ -135,7 +139,7 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { useTranslationsNew } from '~/composables/useTranslationsNew'
 import { useSettingsNew } from '~/composables/useSettingsNew'
 
@@ -150,7 +154,9 @@ const { isDark, toggleDark } = useSettingsNew()
 // 使用翻译数据
 const {
   namespaces,
+  availableLanguages,
   languages,
+  baseLanguage,
   activeNamespace,
   currentLanguage,
   translationEntries,
@@ -160,9 +166,15 @@ const {
   showOnlyUntranslated,
   untranslatedCount,
   selectNamespace,
+  selectLanguage: selectLanguageInStore,
   toggleUntranslatedFilter,
   loadNamespaces,
-  loadNamespaceTranslations
+  loadNamespaceTranslations,
+  loadAvailableLanguages,
+  addTranslationKey,
+  updateTranslation,
+  addLanguage,
+  dialog
 } = useTranslationsNew()
 
 // 当前命名空间信息
@@ -170,34 +182,175 @@ const currentNamespace = computed(() =>
   namespaces.value.find(ns => ns.name === activeNamespace.value)
 )
 
-// 处理添加新键
-const handleAddKey = (data) => {
-  console.log('Adding new key:', data)
-  // TODO: 实现添加新键的逻辑
-  // 调用 API 添加新键到当前命名空间
+const route = useRoute()
+
+const showAlert = async (message: string) => {
+  if (dialog) {
+    await dialog.alert(message)
+  } else if (import.meta.client) {
+    alert(message)
+  }
 }
 
-// 处理添加新语言
-const handleAddLanguage = (data) => {
-  console.log('Adding new language:', data)
-  // TODO: 实现添加新语言的逻辑
-  // 调用 API 为所有命名空间添加新语言文件
+const handleAddKey = async (data: { key: string; translation: string }) => {
+  if (!activeNamespace.value) {
+    await showAlert('请先选择一个命名空间后再添加翻译键。')
+    return
+  }
+
+  const trimmedKey = data.key.trim()
+  const trimmedTranslation = data.translation.trim()
+  if (!trimmedKey) {
+    await showAlert('翻译键名称不能为空。')
+    return
+  }
+
+  const initialValues: Record<string, any> = {}
+  const baseCode = baseLanguage.value?.code
+  if (baseCode && trimmedTranslation) {
+    initialValues[baseCode] = trimmedTranslation
+  }
+
+  try {
+    const created = await addTranslationKey(trimmedKey, initialValues)
+
+    if (!created) {
+      await showAlert('添加翻译键失败：该键可能已经存在。')
+      return
+    }
+
+    if (baseCode && trimmedTranslation) {
+      updateTranslation(trimmedKey, baseCode, trimmedTranslation)
+    }
+
+    await showAlert('新的翻译键已添加，请记得保存更改。')
+  } catch (error) {
+    console.error('Failed to add translation key:', error)
+    await showAlert('添加翻译键时出现问题，请稍后再试。')
+  }
 }
 
-// 页面加载时获取数据
+const handleAddLanguage = async (data: { code: string; name: string }) => {
+  const languageCode = data.code.trim()
+  const displayName = data.name.trim() || languageCode
+
+  if (!languageCode) {
+    await showAlert('语言代码不能为空。')
+    return
+  }
+
+  try {
+    const created = await addLanguage(languageCode, displayName)
+
+    if (!created) {
+      await showAlert('该语言已存在或创建失败。')
+      return
+    }
+
+    await loadAvailableLanguages()
+    await showAlert(`语言 ${displayName} 已添加。`)
+  } catch (error) {
+    console.error('Failed to add language:', error)
+    await showAlert('添加语言时出现问题，请稍后再试。')
+  }
+}
+
+const ensureNamespaceSelection = async (
+  namespaceName: string | undefined,
+  { forceReload = false }: { forceReload?: boolean } = {}
+) => {
+  if (!namespaceName || typeof namespaceName !== 'string') {
+    return
+  }
+
+  if (!namespaces.value?.some((ns) => ns.name === namespaceName)) {
+    console.warn(`Namespace ${namespaceName} is not available`)
+    return
+  }
+
+  if (namespaceName === activeNamespace.value) {
+    if (forceReload) {
+      await loadNamespaceTranslations(namespaceName)
+    }
+    return
+  }
+
+  await selectNamespace(namespaceName)
+}
+
+const handleLanguageChange = async (event: Event) => {
+  const target = event.target as HTMLSelectElement
+  const nextLanguage = target.value
+
+  if (!nextLanguage || nextLanguage === currentLanguage.value) {
+    return
+  }
+
+  try {
+    const switched = await selectLanguageInStore(nextLanguage)
+    if (!switched && import.meta.client) {
+      target.value = currentLanguage.value
+    }
+  } catch (error) {
+    console.error('Failed to switch language from editor sidebar:', error)
+    await showAlert('切换语言时出现问题，请稍后再试。')
+    if (import.meta.client) {
+      target.value = currentLanguage.value
+    }
+  }
+}
+
 onMounted(async () => {
+  await loadAvailableLanguages()
   await loadNamespaces()
 
-  // 检查URL参数中是否有指定的命名空间
-  const route = useRoute()
-  const namespaceFromQuery = route.query.namespace
+  const namespaceFromQuery = typeof route.query.namespace === 'string'
+    ? route.query.namespace
+    : undefined
 
   if (namespaceFromQuery) {
-    // 如果URL中有命名空间参数，自动选择该命名空间
-    await selectNamespace(namespaceFromQuery)
-  } else if (activeNamespace.value) {
-    // 如果有预选的 namespace，加载其翻译数据
+    await ensureNamespaceSelection(namespaceFromQuery, { forceReload: true })
+    return
+  }
+
+  if (activeNamespace.value) {
     await loadNamespaceTranslations(activeNamespace.value)
+    return
+  }
+
+  if (namespaces.value?.length) {
+    await selectNamespace(namespaces.value[0].name)
   }
 })
+
+watch(
+  () => route.query.namespace,
+  async (namespace) => {
+    if (typeof namespace === 'string') {
+      await ensureNamespaceSelection(namespace, { forceReload: true })
+    }
+  }
+)
+
+watch(
+  () => namespaces.value,
+  async (namespaceList) => {
+    if (!namespaceList || namespaceList.length === 0) {
+      return
+    }
+
+    const namespaceFromQuery = typeof route.query.namespace === 'string'
+      ? route.query.namespace
+      : undefined
+
+    if (namespaceFromQuery) {
+      await ensureNamespaceSelection(namespaceFromQuery)
+      return
+    }
+
+    if (!activeNamespace.value) {
+      await selectNamespace(namespaceList[0].name)
+    }
+  }
+)
 </script>

--- a/packages/locales-web/pages/index.vue
+++ b/packages/locales-web/pages/index.vue
@@ -31,7 +31,7 @@
             <div class="text-sm text-gray-500 dark:text-gray-400">Translation Keys</div>
           </div>
           <div>
-            <div class="text-2xl font-light text-gray-900 dark:text-gray-100 mb-1">{{ languages.length || 2 }}</div>
+            <div class="text-2xl font-light text-gray-900 dark:text-gray-100 mb-1">{{ languageCount || 0 }}</div>
             <div class="text-sm text-gray-500 dark:text-gray-400">Languages</div>
           </div>
           <div>
@@ -137,7 +137,7 @@ useHead({
 const { isDark, toggleDark } = useSettingsNew()
 
 // 使用翻译数据
-const { namespaces, languages, loadNamespaces } = useTranslationsNew()
+const { namespaces, availableLanguages, loadNamespaces, loadAvailableLanguages } = useTranslationsNew()
 
 // 计算统计信息
 const totalKeys = computed(() => {
@@ -151,9 +151,11 @@ const averageProgress = computed(() => {
   return Math.round(total / namespaces.value.length)
 })
 
+const languageCount = computed(() => availableLanguages.value?.length || 0)
+
 // 刷新命名空间
 async function refreshNamespaces() {
-  await loadNamespaces()
+  await Promise.all([loadAvailableLanguages(), loadNamespaces()])
 }
 
 // 导航到指定命名空间
@@ -163,7 +165,8 @@ async function navigateToNamespace(namespaceName) {
 }
 
 // 页面加载时获取数据
-onMounted(() => {
-  loadNamespaces()
+onMounted(async () => {
+  await loadAvailableLanguages()
+  await loadNamespaces()
 })
 </script>

--- a/packages/locales-web/stores/translations.ts
+++ b/packages/locales-web/stores/translations.ts
@@ -217,8 +217,46 @@ export const useTranslationsStore = defineStore('translations', {
     },
 
     // 语言选择管理 - 改为单选
-    selectLanguage(languageCode: string) {
+    async selectLanguage(languageCode: string): Promise<boolean> {
+      if (!languageCode || languageCode === this.currentLanguage) {
+        return true
+      }
+
+      const targetLanguage = this.availableLanguages.find((lang) => lang.code === languageCode)
+      if (!targetLanguage) {
+        console.warn(`Language ${languageCode} is not registered in availableLanguages`)
+        if (import.meta.client) {
+          alert('所选语言不存在，请刷新后重试')
+        }
+        return false
+      }
+
+      if (this.hasUnsavedChanges) {
+        let shouldProceed = true
+        if (import.meta.client) {
+          shouldProceed = confirm('存在未保存的改动，切换语言会先保存这些更改，是否继续？')
+        }
+
+        if (!shouldProceed) {
+          return false
+        }
+
+        const saved = await this.saveAllChanges()
+        if (!saved) {
+          if (import.meta.client) {
+            alert('保存失败，已取消语言切换，请稍后重试。')
+          }
+          return false
+        }
+      }
+
       this.currentLanguage = languageCode
+
+      if (this.activeNamespace) {
+        await this.loadNamespaceTranslations(this.activeNamespace)
+      }
+
+      return true
     },
 
     // 切换筛选状态
@@ -264,7 +302,10 @@ export const useTranslationsStore = defineStore('translations', {
     },
 
     // 添加新的翻译键
-    async addTranslationKey(keyPath: string): Promise<boolean> {
+    async addTranslationKey(
+      keyPath: string,
+      initialValues: Record<string, any> = {}
+    ): Promise<boolean> {
       if (!this.activeNamespace) return false
 
       // 检查键是否已存在
@@ -277,22 +318,42 @@ export const useTranslationsStore = defineStore('translations', {
         return false
       }
 
+      const languageSources = this.availableLanguages.length
+        ? this.availableLanguages
+        : this.languages
+
+      const values = languageSources.reduce(
+        (acc, lang) => {
+          acc[lang.code] = initialValues[lang.code] ?? ''
+          return acc
+        },
+        {} as Record<string, any>
+      )
+
+      const sampleValue = values[this.baseLanguage.code]
+      let detectedType: 'string' | 'array' | 'object' | 'number' | 'boolean' = 'string'
+
+      if (Array.isArray(sampleValue)) {
+        detectedType = 'array'
+      } else if (typeof sampleValue === 'object' && sampleValue !== null) {
+        detectedType = 'object'
+      } else if (typeof sampleValue === 'number') {
+        detectedType = 'number'
+      } else if (typeof sampleValue === 'boolean') {
+        detectedType = 'boolean'
+      }
+
       // 添加新条目
       const newEntry: TranslationEntry = {
         key: keyPath.split('.').pop() || keyPath,
         path: keyPath,
-        values: this.languages.reduce(
-          (acc, lang) => {
-            acc[lang.code] = ''
-            return acc
-          },
-          {} as Record<string, any>
-        ),
-        type: 'string',
+        values,
+        type: detectedType,
         isModified: true
       }
 
       this.translationEntries.push(newEntry)
+      this.translationEntries.sort((a, b) => a.path.localeCompare(b.path))
       this.hasUnsavedChanges = true
 
       return true
@@ -378,7 +439,20 @@ export const useTranslationsStore = defineStore('translations', {
         const response =
           await $fetch<ApiResponse<{ languages: Language[]; count: number }>>('/api/languages')
         if (response.success && response.data) {
-          this.availableLanguages = response.data.languages
+          const previousLanguages = new Map(
+            this.availableLanguages.map((lang) => [lang.code, lang])
+          )
+
+          this.availableLanguages = response.data.languages.map((lang) => {
+            const existing = previousLanguages.get(lang.code)
+            if (existing) {
+              return {
+                ...lang,
+                name: existing.name || lang.name
+              }
+            }
+            return lang
+          })
 
           // 如果当前语言不在可用语言中，切换到基准语言
           const currentExists = this.availableLanguages.some(


### PR DESCRIPTION
## Summary
- make language switching asynchronous with save confirmations, allow seeding new translation keys, and keep existing language labels when reloading
- load available languages ahead of namespaces on the home and editor pages, select default namespaces from route changes, and surface add key/language flows through dialogs
- update the header language popover to use the full language list and provide feedback when switching

## Testing
- pnpm -C packages/locales-web build

------
https://chatgpt.com/codex/tasks/task_e_68d11b1ec6c083218f87237d16bece5a