### PR TITLE
feat(locales-web): replace native alerts with global dialog

### DIFF
--- a/packages/locales-web/components/AppHeader.vue
+++ b/packages/locales-web/components/AppHeader.vue
@@ -50,7 +50,7 @@
 
             <template #content>
               <div class="py-1 min-w-36">
-                <button v-for="lang in availableLanguages.filter(l => l.code !== currentLanguage)" :key="lang.code"
+                <button v-for="lang in languageOptions.filter(l => l.code !== currentLanguage)" :key="lang.code"
                   @click="selectLanguage(lang.code)"
                   class="w-full text-left px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors rounded-sm flex items-center gap-2">
                   <div class="i-carbon-language text-xs opacity-60"></div>
@@ -90,7 +90,7 @@
   </header>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { useSettingsNew } from '~/composables/useSettingsNew'
 import { useTranslationsNew } from '~/composables/useTranslationsNew'
 
@@ -102,10 +102,12 @@ const route = useRoute()
 const isEditingPage = computed(() => route.path === '/editor')
 
 const {
-  languages,
+  availableLanguages,
   currentLanguage,
   hasUnsavedChanges,
   saveAllChanges,
+  selectLanguage: selectLanguageInStore,
+  dialog,
   activeNamespace,
   namespaces
 } = useTranslationsNew()
@@ -117,15 +119,19 @@ const showSaveButton = computed(() => isEditingPage.value && hasUnsavedChanges.v
 const languageSelectorRef = ref()
 
 // 可用语言列表
-const availableLanguages = computed(() => languages.value || [
-  { code: 'zh-CN', name: '简体中文' },
+const fallbackLanguages = [
+  { code: 'zh-CN', name: 'Simplified Chinese' },
   { code: 'en-US', name: 'English' }
-])
+]
+
+const languageOptions = computed(() =>
+  availableLanguages.value?.length ? availableLanguages.value : fallbackLanguages
+)
 
 // 当前语言信息
 const getCurrentLanguage = computed(() => {
-  return availableLanguages.value.find(lang => lang.code === currentLanguage.value) ||
-    availableLanguages.value[0]
+  const list = languageOptions.value
+  return list.find((lang) => lang.code === currentLanguage.value) || list[0]
 })
 
 // 当前命名空间信息
@@ -172,14 +178,28 @@ function getProgressColor(progress) {
 }
 
 // 选择语言
-function selectLanguage(languageCode) {
-  // TODO: 实现语言切换逻辑
-  console.log('Select language:', languageCode)
-  languageSelectorRef.value?.close()
+async function selectLanguage(languageCode: string) {
+  if (!languageCode || languageCode === currentLanguage.value) {
+    languageSelectorRef.value?.close()
+    return
+  }
+
+  try {
+    const switched = await selectLanguageInStore(languageCode)
+    if (switched) {
+      languageSelectorRef.value?.close()
+    }
+  } catch (error) {
+    console.error('Failed to switch language:', error)
+    if (dialog) {
+      await dialog.alert('We ran into a problem while switching languages. Please try again.', {
+        title: 'Language switch failed'
+      })
+    }
+  }
 }
 
-// 处理语言选择确认
-function handleLanguageSelect(languageCode) {
-  selectLanguage(languageCode)
+async function handleLanguageSelect(languageCode: string) {
+  await selectLanguage(languageCode)
 }
 </script>

--- a/packages/locales-web/components/GlobalDialog.vue
+++ b/packages/locales-web/components/GlobalDialog.vue
@@ -1,0 +1,118 @@
+<template>
+  <Teleport to="body">
+    <Transition name="fade">
+      <div
+        v-if="isOpen"
+        class="fixed inset-0 z-[1000] flex items-center justify-center bg-black/30 backdrop-blur-sm px-4"
+        role="presentation"
+        @click.self="handleSecondary"
+      >
+        <div
+          class="w-full max-w-md rounded-lg border border-antfu-border bg-antfu-bg shadow-xl"
+          role="dialog"
+          aria-modal="true"
+        >
+          <div class="px-5 pt-5">
+            <h3 v-if="options.title" class="text-base font-medium text-antfu-text">
+              {{ options.title }}
+            </h3>
+            <p v-if="options.message" class="mt-2 text-sm text-antfu-text-mute whitespace-pre-line">
+              {{ options.message }}
+            </p>
+            <div v-if="isPrompt" class="mt-4">
+              <input
+                v-model="promptValue"
+                :placeholder="options.placeholder || 'Enter a value'"
+                class="w-full rounded border border-antfu-border bg-antfu-bg px-3 py-2 text-sm text-antfu-text focus:border-emerald-500 focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                ref="promptInput"
+                @keyup.enter="handlePrimary"
+              />
+            </div>
+          </div>
+          <div class="flex items-center justify-end gap-2 px-5 py-4 bg-antfu-soft">
+            <button
+              v-if="isConfirm || isPrompt"
+              type="button"
+              class="rounded border border-antfu-border px-3 py-1.5 text-xs text-antfu-text-soft hover:text-antfu-text hover:bg-antfu-bg transition-colors"
+              @click="handleSecondary"
+            >
+              {{ options.cancelText || 'Cancel' }}
+            </button>
+            <button
+              type="button"
+              class="rounded bg-emerald-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-emerald-700 transition-colors"
+              @click="handlePrimary"
+              ref="primaryButton"
+            >
+              {{ options.confirmText || 'OK' }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import { useEventListener } from '@vueuse/core'
+import { useDialog } from '~/composables/useDialog'
+
+const dialog = useDialog()
+
+const isOpen = computed(() => dialog.isOpen.value)
+const options = computed(() => dialog.dialogOptions.value)
+const isPrompt = computed(() => options.value.type === 'prompt')
+const isConfirm = computed(() => options.value.type === 'confirm')
+const promptValue = ref('')
+const primaryButton = ref<HTMLButtonElement | null>(null)
+const promptInput = ref<HTMLInputElement | null>(null)
+
+watch(isOpen, (open) => {
+  if (open) {
+    promptValue.value = ''
+    nextTick(() => {
+      if (isPrompt.value) {
+        promptInput.value?.focus()
+      } else {
+        primaryButton.value?.focus()
+      }
+    })
+  } else {
+    promptValue.value = ''
+  }
+})
+
+const handlePrimary = () => {
+  if (isPrompt.value) {
+    dialog.handleConfirm(promptValue.value)
+  } else {
+    dialog.handleConfirm()
+  }
+}
+
+const handleSecondary = () => {
+  dialog.handleCancel()
+}
+
+useEventListener('keydown', (event: KeyboardEvent) => {
+  if (!isOpen.value) return
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    dialog.handleCancel()
+  }
+})
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+  transform: scale(0.98);
+}
+</style>

--- a/packages/locales-web/components/editor/ActionCell.vue
+++ b/packages/locales-web/components/editor/ActionCell.vue
@@ -5,41 +5,43 @@
       <button
         @click="handleDelete"
         class="p-1 opacity-0 group-hover:opacity-100 text-antfu-text-mute hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-all"
-        title="删除此翻译键"
+        title="Delete this translation key"
       >
         <div class="i-carbon-trash-can text-xs"></div>
       </button>
-      
+
       <!-- 复制按钮 -->
       <button
         @click="handleCopy"
         class="p-1 opacity-0 group-hover:opacity-100 text-antfu-text-mute hover:text-antfu-text hover:bg-antfu-soft rounded transition-all"
-        title="复制翻译键路径"
+        title="Copy translation key path"
       >
         <div class="i-carbon-copy text-xs"></div>
       </button>
-      
+
       <!-- 编辑按钮（用于复杂类型） -->
       <button
         v-if="showEditButton"
         @click="handleEdit"
         class="p-1 opacity-0 group-hover:opacity-100 text-antfu-text-mute hover:text-antfu-text hover:bg-antfu-soft rounded transition-all"
-        title="编辑"
+        title="Edit value"
       >
         <div class="i-carbon-edit text-xs"></div>
       </button>
-      
+
       <!-- 修改状态指示器 -->
       <div
         v-if="isModified"
         class="w-2 h-2 bg-emerald-500 rounded-full"
-        title="已修改"
+        title="Unsaved change"
       ></div>
     </div>
   </td>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useDialog } from '~/composables/useDialog'
 import type { TranslationEntry } from '~/types'
 
 interface Props {
@@ -67,10 +69,17 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<Emits>()
 
 const isModified = computed(() => props.entry.isModified)
+const dialog = useDialog()
 
 async function handleDelete() {
-  // 可以添加确认对话框
-  const confirmed = confirm(`确定要删除翻译键 "${props.entry.path}" 吗？`)
+  const confirmed = await dialog.confirm(
+    `Delete translation key "${props.entry.path}"?`,
+    {
+      title: 'Delete translation key',
+      confirmText: 'Delete',
+      cancelText: 'Cancel'
+    }
+  )
   if (confirmed) {
     emit('delete', props.index)
   }

--- a/packages/locales-web/composables/useDialog.ts
+++ b/packages/locales-web/composables/useDialog.ts
@@ -1,6 +1,8 @@
-import { ref } from 'vue'
+import type { Ref } from 'vue'
+import { readonly, ref } from 'vue'
+import { createGlobalState } from '@vueuse/core'
 
-interface DialogOptions {
+export interface DialogOptions {
   title?: string
   message?: string
   type?: 'alert' | 'confirm' | 'prompt'
@@ -9,19 +11,35 @@ interface DialogOptions {
   cancelText?: string
 }
 
-export const useDialog = () => {
+interface DialogState {
+  isOpen: Ref<boolean>
+  dialogOptions: Ref<DialogOptions>
+  alert: (message: string, options?: Pick<DialogOptions, 'title' | 'confirmText'>) => Promise<void>
+  confirm: (
+    message: string,
+    options?: Pick<DialogOptions, 'title' | 'confirmText' | 'cancelText'>
+  ) => Promise<boolean>
+  prompt: (
+    message: string,
+    options?: Pick<DialogOptions, 'title' | 'placeholder' | 'confirmText' | 'cancelText'>
+  ) => Promise<string | null>
+  handleConfirm: (value?: any) => void
+  handleCancel: () => void
+  closeDialog: () => void
+}
+
+const useDialogState = createGlobalState<() => DialogState>(() => {
   const isOpen = ref(false)
-  const dialogOptions = ref<DialogOptions>({})
+  const dialogOptions = ref<DialogOptions>({ type: 'alert' })
   const resolvePromise = ref<((value: any) => void) | null>(null)
   const rejectPromise = ref<((reason?: any) => void) | null>(null)
 
-  // 显示对话框的通用方法
   const showDialog = (options: DialogOptions): Promise<any> => {
     return new Promise((resolve, reject) => {
       dialogOptions.value = {
         type: 'alert',
-        confirmText: '确定',
-        cancelText: '取消',
+        confirmText: 'OK',
+        cancelText: 'Cancel',
         ...options
       }
 
@@ -31,45 +49,51 @@ export const useDialog = () => {
     })
   }
 
-  // 显示警告对话框
-  const alert = (message: string, title?: string): Promise<void> => {
+  const alert = (
+    message: string,
+    options: Pick<DialogOptions, 'title' | 'confirmText'> = {}
+  ): Promise<void> => {
     return showDialog({
       type: 'alert',
       message,
-      title: title || '提示'
+      title: options.title || 'Notice',
+      confirmText: options.confirmText || 'OK'
     })
   }
 
-  // 显示确认对话框
-  const confirm = (message: string, title?: string): Promise<boolean> => {
+  const confirm = (
+    message: string,
+    options: Pick<DialogOptions, 'title' | 'confirmText' | 'cancelText'> = {}
+  ): Promise<boolean> => {
     return showDialog({
       type: 'confirm',
       message,
-      title: title || '确认'
+      title: options.title || 'Confirmation',
+      confirmText: options.confirmText || 'Confirm',
+      cancelText: options.cancelText || 'Cancel'
     })
   }
 
-  // 显示输入对话框
   const prompt = (
     message: string,
-    placeholder?: string,
-    title?: string
+    options: Pick<DialogOptions, 'title' | 'placeholder' | 'confirmText' | 'cancelText'> = {}
   ): Promise<string | null> => {
     return showDialog({
       type: 'prompt',
       message,
-      placeholder,
-      title: title || '输入'
+      title: options.title || 'Input',
+      placeholder: options.placeholder,
+      confirmText: options.confirmText || 'Confirm',
+      cancelText: options.cancelText || 'Cancel'
     })
   }
 
-  // 处理确认
   const handleConfirm = (value?: any) => {
     if (resolvePromise.value) {
       if (dialogOptions.value.type === 'confirm') {
         resolvePromise.value(true)
       } else if (dialogOptions.value.type === 'prompt') {
-        resolvePromise.value(value || null)
+        resolvePromise.value(value ?? null)
       } else {
         resolvePromise.value(undefined)
       }
@@ -77,43 +101,46 @@ export const useDialog = () => {
     closeDialog()
   }
 
-  // 处理取消
   const handleCancel = () => {
     if (dialogOptions.value.type === 'confirm') {
-      if (resolvePromise.value) {
-        resolvePromise.value(false)
-      }
+      resolvePromise.value?.(false)
     } else if (dialogOptions.value.type === 'prompt') {
-      if (resolvePromise.value) {
-        resolvePromise.value(null)
-      }
+      resolvePromise.value?.(null)
     } else {
-      if (rejectPromise.value) {
-        rejectPromise.value()
-      }
+      rejectPromise.value?.()
     }
     closeDialog()
   }
 
-  // 关闭对话框
   const closeDialog = () => {
     isOpen.value = false
     resolvePromise.value = null
     rejectPromise.value = null
-    dialogOptions.value = {}
+    dialogOptions.value = { type: 'alert' }
   }
 
   return {
-    // 状态
-    isOpen: readonly(isOpen),
-    dialogOptions: readonly(dialogOptions),
-
-    // 方法
+    isOpen,
+    dialogOptions,
     alert,
     confirm,
     prompt,
     handleConfirm,
     handleCancel,
     closeDialog
+  }
+})
+
+export const useDialog = () => {
+  const state = useDialogState()
+  return {
+    isOpen: readonly(state.isOpen),
+    dialogOptions: readonly(state.dialogOptions),
+    alert: state.alert,
+    confirm: state.confirm,
+    prompt: state.prompt,
+    handleConfirm: state.handleConfirm,
+    handleCancel: state.handleCancel,
+    closeDialog: state.closeDialog
   }
 }

--- a/packages/locales-web/composables/useTranslations.ts
+++ b/packages/locales-web/composables/useTranslations.ts
@@ -143,9 +143,23 @@ export const useTranslations = () => {
     }
 
     if (hasUnsavedChanges.value) {
-      const shouldSave = confirm('有未保存的修改，是否保存？')
+      const shouldSave = await dialog.confirm(
+        'You have unsaved changes. Save them before switching namespaces? Choosing "Skip" will discard those edits.',
+        {
+          title: 'Unsaved changes',
+          confirmText: 'Save & Switch',
+          cancelText: 'Skip Save'
+        }
+      )
       if (shouldSave) {
-        await saveAllChanges()
+        const saved = await saveAllChanges()
+        if (!saved) {
+          await dialog.alert(
+            'We could not save your changes. Resolve the issue and try again before switching namespaces.',
+            { title: 'Save failed' }
+          )
+          return
+        }
       }
     }
 
@@ -338,7 +352,9 @@ export const useTranslations = () => {
     // 检查键是否已存在
     const exists = translationEntries.value.some((entry) => entry.path === keyPath)
     if (exists) {
-      await dialog.alert('该键已存在')
+      await dialog.alert('This translation key already exists.', {
+        title: 'Duplicate key'
+      })
       return false
     }
 
@@ -399,7 +415,9 @@ export const useTranslations = () => {
     // 检查语言是否已存在
     const exists = availableLanguages.value.some((lang) => lang.code === code)
     if (exists) {
-      await dialog.alert('该语言已存在')
+      await dialog.alert('This language already exists.', {
+        title: 'Duplicate language'
+      })
       return false
     }
 
@@ -425,7 +443,9 @@ export const useTranslations = () => {
       // 检查语言是否已存在
       const exists = availableLanguages.value.some((lang) => lang.code === code)
       if (exists) {
-        await dialog.alert('该语言已存在')
+        await dialog.alert('This language already exists.', {
+          title: 'Duplicate language'
+        })
         return false
       }
 
@@ -449,13 +469,17 @@ export const useTranslations = () => {
 
         return true
       } else {
-        await dialog.alert('添加语言失败')
+        await dialog.alert('Failed to create the language file. Please try again.', {
+          title: 'Operation failed'
+        })
         return false
       }
     } catch (error) {
       console.error('Error adding language:', error)
       const errorMessage = error instanceof Error ? error.message : String(error)
-      await dialog.alert(`添加语言失败: ${errorMessage}`)
+      await dialog.alert(`Failed to add the language: ${errorMessage}`, {
+        title: 'Operation failed'
+      })
       return false
     }
   }

--- a/packages/locales-web/layouts/default.vue
+++ b/packages/locales-web/layouts/default.vue
@@ -7,11 +7,15 @@
     <main class="max-w-6xl mx-auto h-[calc(100vh-3rem)]">
       <slot />
     </main>
+
+    <!-- 全局对话框 -->
+    <GlobalDialog />
   </div>
 </template>
 
 <script setup>
 import { useSettingsNew } from '~/composables/useSettingsNew'
+import GlobalDialog from '~/components/GlobalDialog.vue'
 
 // 初始化设置
 const { isDark } = useSettingsNew()

--- a/packages/locales-web/pages/editor.vue
+++ b/packages/locales-web/pages/editor.vue
@@ -25,9 +25,9 @@
         <h3 class="text-sm font-medium text-antfu-text mb-3">
           Current Language
         </h3>
-        <select v-model="currentLanguage"
+        <select :value="currentLanguage" @change="handleLanguageChange"
           class="w-full px-3 py-2 text-sm border border-antfu-border bg-antfu-bg text-antfu-text rounded focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500">
-          <option v-for="lang in languages" :key="lang.code" :value="lang.code">
+          <option v-for="lang in availableLanguages" :key="lang.code" :value="lang.code">
             {{ lang.name }} {{ lang.isBase ? '(Base)' : '' }}
           </option>
         </select>
@@ -110,7 +110,11 @@
             </button>
 
             <!-- 添加键按钮 -->
-            <AddKeyPopover :namespace="activeNamespace" :base-language="currentLanguage" @add-key="handleAddKey" />
+            <AddKeyPopover
+              :namespace="activeNamespace"
+              :base-language="baseLanguage?.name || baseLanguage?.code || 'Base'"
+              @add-key="handleAddKey"
+            />
 
             <!-- 添加语言按钮 -->
             <AddLanguagePopover @add-language="handleAddLanguage" />
@@ -135,7 +139,7 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { useTranslationsNew } from '~/composables/useTranslationsNew'
 import { useSettingsNew } from '~/composables/useSettingsNew'
 
@@ -150,7 +154,9 @@ const { isDark, toggleDark } = useSettingsNew()
 // 使用翻译数据
 const {
   namespaces,
+  availableLanguages,
   languages,
+  baseLanguage,
   activeNamespace,
   currentLanguage,
   translationEntries,
@@ -160,9 +166,15 @@ const {
   showOnlyUntranslated,
   untranslatedCount,
   selectNamespace,
+  selectLanguage: selectLanguageInStore,
   toggleUntranslatedFilter,
   loadNamespaces,
-  loadNamespaceTranslations
+  loadNamespaceTranslations,
+  loadAvailableLanguages,
+  addTranslationKey,
+  updateTranslation,
+  addLanguage,
+  dialog
 } = useTranslationsNew()
 
 // 当前命名空间信息
@@ -170,34 +182,191 @@ const currentNamespace = computed(() =>
   namespaces.value.find(ns => ns.name === activeNamespace.value)
 )
 
-// 处理添加新键
-const handleAddKey = (data) => {
-  console.log('Adding new key:', data)
-  // TODO: 实现添加新键的逻辑
-  // 调用 API 添加新键到当前命名空间
+const route = useRoute()
+
+const showAlert = async (message: string, options?: { title?: string }) => {
+  if (dialog) {
+    await dialog.alert(message, options)
+  } else {
+    console.warn(message)
+  }
 }
 
-// 处理添加新语言
-const handleAddLanguage = (data) => {
-  console.log('Adding new language:', data)
-  // TODO: 实现添加新语言的逻辑
-  // 调用 API 为所有命名空间添加新语言文件
+const handleAddKey = async (data: { key: string; translation: string }) => {
+  if (!activeNamespace.value) {
+    await showAlert('Select a namespace before adding translation keys.', {
+      title: 'Namespace required'
+    })
+    return
+  }
+
+  const trimmedKey = data.key.trim()
+  const trimmedTranslation = data.translation.trim()
+  if (!trimmedKey) {
+    await showAlert('The translation key cannot be empty.', { title: 'Missing key' })
+    return
+  }
+
+  const initialValues: Record<string, any> = {}
+  const baseCode = baseLanguage.value?.code
+  if (baseCode && trimmedTranslation) {
+    initialValues[baseCode] = trimmedTranslation
+  }
+
+  try {
+    const created = await addTranslationKey(trimmedKey, initialValues)
+
+    if (!created) {
+      await showAlert('Failed to add the translation key. It may already exist.', {
+        title: 'Operation failed'
+      })
+      return
+    }
+
+    if (baseCode && trimmedTranslation) {
+      updateTranslation(trimmedKey, baseCode, trimmedTranslation)
+    }
+
+    await showAlert('New translation key added. Remember to save your changes.', {
+      title: 'Translation key added'
+    })
+  } catch (error) {
+    console.error('Failed to add translation key:', error)
+    await showAlert('Something went wrong while adding the translation key. Please try again.', {
+      title: 'Operation failed'
+    })
+  }
 }
 
-// 页面加载时获取数据
+const handleAddLanguage = async (data: { code: string; name: string }) => {
+  const languageCode = data.code.trim()
+  const displayName = data.name.trim() || languageCode
+
+  if (!languageCode) {
+    await showAlert('Language code is required.', { title: 'Missing language code' })
+    return
+  }
+
+  try {
+    const created = await addLanguage(languageCode, displayName)
+
+    if (!created) {
+      await showAlert('The language already exists or could not be created.', {
+        title: 'Operation failed'
+      })
+      return
+    }
+
+    await loadAvailableLanguages()
+    await showAlert(`Language ${displayName} has been added.`, {
+      title: 'Language created'
+    })
+  } catch (error) {
+    console.error('Failed to add language:', error)
+    await showAlert('Something went wrong while adding the language. Please try again.', {
+      title: 'Operation failed'
+    })
+  }
+}
+
+const ensureNamespaceSelection = async (
+  namespaceName: string | undefined,
+  { forceReload = false }: { forceReload?: boolean } = {}
+) => {
+  if (!namespaceName || typeof namespaceName !== 'string') {
+    return
+  }
+
+  if (!namespaces.value?.some((ns) => ns.name === namespaceName)) {
+    console.warn(`Namespace ${namespaceName} is not available`)
+    return
+  }
+
+  if (namespaceName === activeNamespace.value) {
+    if (forceReload) {
+      await loadNamespaceTranslations(namespaceName)
+    }
+    return
+  }
+
+  await selectNamespace(namespaceName)
+}
+
+const handleLanguageChange = async (event: Event) => {
+  const target = event.target as HTMLSelectElement
+  const nextLanguage = target.value
+
+  if (!nextLanguage || nextLanguage === currentLanguage.value) {
+    return
+  }
+
+  try {
+    const switched = await selectLanguageInStore(nextLanguage)
+    if (!switched && import.meta.client) {
+      target.value = currentLanguage.value
+    }
+  } catch (error) {
+    console.error('Failed to switch language from editor sidebar:', error)
+    await showAlert('We ran into a problem while switching languages. Please try again.', {
+      title: 'Language switch failed'
+    })
+    if (import.meta.client) {
+      target.value = currentLanguage.value
+    }
+  }
+}
+
 onMounted(async () => {
+  await loadAvailableLanguages()
   await loadNamespaces()
 
-  // 检查URL参数中是否有指定的命名空间
-  const route = useRoute()
-  const namespaceFromQuery = route.query.namespace
+  const namespaceFromQuery = typeof route.query.namespace === 'string'
+    ? route.query.namespace
+    : undefined
 
   if (namespaceFromQuery) {
-    // 如果URL中有命名空间参数，自动选择该命名空间
-    await selectNamespace(namespaceFromQuery)
-  } else if (activeNamespace.value) {
-    // 如果有预选的 namespace，加载其翻译数据
+    await ensureNamespaceSelection(namespaceFromQuery, { forceReload: true })
+    return
+  }
+
+  if (activeNamespace.value) {
     await loadNamespaceTranslations(activeNamespace.value)
+    return
+  }
+
+  if (namespaces.value?.length) {
+    await selectNamespace(namespaces.value[0].name)
   }
 })
+
+watch(
+  () => route.query.namespace,
+  async (namespace) => {
+    if (typeof namespace === 'string') {
+      await ensureNamespaceSelection(namespace, { forceReload: true })
+    }
+  }
+)
+
+watch(
+  () => namespaces.value,
+  async (namespaceList) => {
+    if (!namespaceList || namespaceList.length === 0) {
+      return
+    }
+
+    const namespaceFromQuery = typeof route.query.namespace === 'string'
+      ? route.query.namespace
+      : undefined
+
+    if (namespaceFromQuery) {
+      await ensureNamespaceSelection(namespaceFromQuery)
+      return
+    }
+
+    if (!activeNamespace.value) {
+      await selectNamespace(namespaceList[0].name)
+    }
+  }
+)
 </script>

--- a/packages/locales-web/pages/index.vue
+++ b/packages/locales-web/pages/index.vue
@@ -31,7 +31,7 @@
             <div class="text-sm text-gray-500 dark:text-gray-400">Translation Keys</div>
           </div>
           <div>
-            <div class="text-2xl font-light text-gray-900 dark:text-gray-100 mb-1">{{ languages.length || 2 }}</div>
+            <div class="text-2xl font-light text-gray-900 dark:text-gray-100 mb-1">{{ languageCount || 0 }}</div>
             <div class="text-sm text-gray-500 dark:text-gray-400">Languages</div>
           </div>
           <div>
@@ -137,7 +137,7 @@ useHead({
 const { isDark, toggleDark } = useSettingsNew()
 
 // 使用翻译数据
-const { namespaces, languages, loadNamespaces } = useTranslationsNew()
+const { namespaces, availableLanguages, loadNamespaces, loadAvailableLanguages } = useTranslationsNew()
 
 // 计算统计信息
 const totalKeys = computed(() => {
@@ -151,9 +151,11 @@ const averageProgress = computed(() => {
   return Math.round(total / namespaces.value.length)
 })
 
+const languageCount = computed(() => availableLanguages.value?.length || 0)
+
 // 刷新命名空间
 async function refreshNamespaces() {
-  await loadNamespaces()
+  await Promise.all([loadAvailableLanguages(), loadNamespaces()])
 }
 
 // 导航到指定命名空间
@@ -163,7 +165,8 @@ async function navigateToNamespace(namespaceName) {
 }
 
 // 页面加载时获取数据
-onMounted(() => {
-  loadNamespaces()
+onMounted(async () => {
+  await loadAvailableLanguages()
+  await loadNamespaces()
 })
 </script>

--- a/packages/locales-web/pages/test-pinia.vue
+++ b/packages/locales-web/pages/test-pinia.vue
@@ -113,6 +113,7 @@
 import { useTranslationsNew } from '~/composables/useTranslationsNew'
 import { useSettingsNew } from '~/composables/useSettingsNew'
 import { useFileSystemNew } from '~/composables/useFileSystemNew'
+import { useDialog } from '~/composables/useDialog'
 
 // 设置页面标题
 useHead({
@@ -123,6 +124,7 @@ useHead({
 const settings = useSettingsNew()
 const translations = useTranslationsNew()
 const fileSystem = useFileSystemNew()
+const dialog = useDialog()
 
 // 测试方法
 const reloadPage = () => {
@@ -131,11 +133,13 @@ const reloadPage = () => {
   }
 }
 
-const exportSettings = () => {
+const exportSettings = async () => {
   const settingsJson = settings.exportSettings()
   console.log('导出的设置:', settingsJson)
   if (import.meta.client) {
-    alert('设置已导出到控制台')
+    await dialog.alert('Settings have been logged to the console.', {
+      title: 'Export complete'
+    })
   }
 }
 
@@ -149,32 +153,40 @@ const testBatchUpdate = async () => {
   const result = await translations.batchUpdateTranslations(updates)
   console.log('批量更新结果:', result)
   if (import.meta.client) {
-    alert(`批量更新完成: 成功 ${result.success}, 失败 ${result.failed}`)
+    await dialog.alert(`Batch update complete: ${result.success} succeeded, ${result.failed} failed.`, {
+      title: 'Batch update'
+    })
   }
 }
 
-const testExportJson = () => {
+const testExportJson = async () => {
   const jsonData = translations.exportTranslations('json')
   console.log('导出的 JSON 数据:', jsonData)
   if (import.meta.client) {
-    alert('JSON 数据已导出到控制台')
+    await dialog.alert('JSON export has been logged to the console.', {
+      title: 'Export complete'
+    })
   }
 }
 
-const testExportCsv = () => {
+const testExportCsv = async () => {
   const csvData = translations.exportTranslations('csv')
   console.log('导出的 CSV 数据:', csvData)
   if (import.meta.client) {
-    alert('CSV 数据已导出到控制台')
+    await dialog.alert('CSV export has been logged to the console.', {
+      title: 'Export complete'
+    })
   }
 }
 
-const resetAllStores = () => {
+const resetAllStores = async () => {
   translations.resetStore()
   settings.resetSettings()
   fileSystem.clearError()
   if (import.meta.client) {
-    alert('所有状态已重置')
+    await dialog.alert('All store state has been reset.', {
+      title: 'Reset complete'
+    })
   }
 }
 

--- a/packages/locales-web/stores/translations.ts
+++ b/packages/locales-web/stores/translations.ts
@@ -1,5 +1,13 @@
 import { defineStore } from 'pinia'
+import { useDialog } from '~/composables/useDialog'
 import type { Language, Namespace, TranslationEntry, ApiResponse, TranslationsState } from '~/types'
+
+const getDialog = () => {
+  if (import.meta.client) {
+    return useDialog()
+  }
+  return null
+}
 
 // 检查值是否未翻译的辅助函数
 function isValueUntranslated(value: any): boolean {
@@ -190,22 +198,44 @@ export const useTranslationsStore = defineStore('translations', {
     },
 
     // 选择命名空间
-    async selectNamespace(namespace: string) {
-      // 如果选择的是当前命名空间，直接返回
-      if (this.activeNamespace === namespace) {
-        return
+    async selectNamespace(namespace: string): Promise<boolean> {
+      if (!namespace || this.activeNamespace === namespace) {
+        return true
       }
 
+      const dialog = getDialog()
+
       if (this.hasUnsavedChanges) {
-        const shouldSave = confirm('有未保存的修改，是否保存？')
-        if (shouldSave) {
-          await this.saveAllChanges()
+        if (dialog) {
+          const shouldSave = await dialog.confirm(
+            'You have unsaved changes. Save them before switching namespaces? Choosing "Skip" will discard those edits.',
+            {
+              title: 'Unsaved changes',
+              confirmText: 'Save & Switch',
+              cancelText: 'Skip Save'
+            }
+          )
+
+          if (shouldSave) {
+            const saved = await this.saveAllChanges()
+            if (!saved) {
+              await dialog.alert(
+                'We could not save your changes. Resolve the issue and try again before switching namespaces.',
+                { title: 'Save failed' }
+              )
+              return false
+            }
+          }
+        } else {
+          const saved = await this.saveAllChanges()
+          if (!saved) {
+            return false
+          }
         }
       }
 
       this.activeNamespace = namespace
 
-      // 更新 URL 参数
       if (import.meta.client) {
         const router = useRouter()
         await router.push({
@@ -214,11 +244,64 @@ export const useTranslationsStore = defineStore('translations', {
       }
 
       await this.loadNamespaceTranslations(namespace)
+      return true
     },
 
     // 语言选择管理 - 改为单选
-    selectLanguage(languageCode: string) {
+    async selectLanguage(languageCode: string): Promise<boolean> {
+      if (!languageCode || languageCode === this.currentLanguage) {
+        return true
+      }
+
+      const targetLanguage = this.availableLanguages.find((lang) => lang.code === languageCode)
+      const dialog = getDialog()
+
+      if (!targetLanguage) {
+        console.warn(`Language ${languageCode} is not registered in availableLanguages`)
+        await dialog?.alert('The selected language is not available. Please refresh and try again.', {
+          title: 'Language unavailable'
+        })
+        return false
+      }
+
+      if (this.hasUnsavedChanges) {
+        if (dialog) {
+          const shouldProceed = await dialog.confirm(
+            'Switching languages will save your pending edits first. Continue?',
+            {
+              title: 'Unsaved changes',
+              confirmText: 'Save & Switch',
+              cancelText: 'Stay'
+            }
+          )
+
+          if (!shouldProceed) {
+            return false
+          }
+
+          const saved = await this.saveAllChanges()
+          if (!saved) {
+            await dialog.alert(
+              'We could not save your changes, so the language was not switched. Please try again.',
+              { title: 'Save failed' }
+            )
+            return false
+          }
+        } else {
+          const saved = await this.saveAllChanges()
+          if (!saved) {
+            return false
+          }
+        }
+      }
+
       this.currentLanguage = languageCode
+
+      if (this.activeNamespace) {
+        await this.loadNamespaceTranslations(this.activeNamespace)
+      }
+
+      return true
     },
 
     // 切换筛选状态
@@ -264,35 +347,55 @@ export const useTranslationsStore = defineStore('translations', {
     },
 
     // 添加新的翻译键
-    async addTranslationKey(keyPath: string): Promise<boolean> {
+    async addTranslationKey(
+      keyPath: string,
+      initialValues: Record<string, any> = {}
+    ): Promise<boolean> {
       if (!this.activeNamespace) return false
 
       // 检查键是否已存在
       const exists = this.translationEntries.some((entry) => entry.path === keyPath)
       if (exists) {
-        // 简单的 alert，避免复杂的依赖
-        if (import.meta.client) {
-          alert('该键已存在')
-        }
+        console.warn(`Translation key "${keyPath}" already exists in ${this.activeNamespace}`)
         return false
+      }
+
+      const languageSources = this.availableLanguages.length
+        ? this.availableLanguages
+        : this.languages
+
+      const values = languageSources.reduce(
+        (acc, lang) => {
+          acc[lang.code] = initialValues[lang.code] ?? ''
+          return acc
+        },
+        {} as Record<string, any>
+      )
+
+      const sampleValue = values[this.baseLanguage.code]
+      let detectedType: 'string' | 'array' | 'object' | 'number' | 'boolean' = 'string'
+
+      if (Array.isArray(sampleValue)) {
+        detectedType = 'array'
+      } else if (typeof sampleValue === 'object' && sampleValue !== null) {
+        detectedType = 'object'
+      } else if (typeof sampleValue === 'number') {
+        detectedType = 'number'
+      } else if (typeof sampleValue === 'boolean') {
+        detectedType = 'boolean'
       }
 
       // 添加新条目
       const newEntry: TranslationEntry = {
         key: keyPath.split('.').pop() || keyPath,
         path: keyPath,
-        values: this.languages.reduce(
-          (acc, lang) => {
-            acc[lang.code] = ''
-            return acc
-          },
-          {} as Record<string, any>
-        ),
-        type: 'string',
+        values,
+        type: detectedType,
         isModified: true
       }
 
       this.translationEntries.push(newEntry)
+      this.translationEntries.sort((a, b) => a.path.localeCompare(b.path))
       this.hasUnsavedChanges = true
 
       return true
@@ -303,9 +406,7 @@ export const useTranslationsStore = defineStore('translations', {
       // 检查语言是否已存在
       const exists = this.availableLanguages.some((lang) => lang.code === code)
       if (exists) {
-        if (import.meta.client) {
-          alert('该语言已存在')
-        }
+        console.warn(`Language ${code} already exists in the available list`)
         return false
       }
 
@@ -331,9 +432,7 @@ export const useTranslationsStore = defineStore('translations', {
         // 检查语言是否已存在
         const exists = this.availableLanguages.some((lang) => lang.code === code)
         if (exists) {
-          if (import.meta.client) {
-            alert('该语言已存在')
-          }
+          console.warn(`Language ${code} already exists in the available list`)
           return false
         }
 
@@ -357,17 +456,13 @@ export const useTranslationsStore = defineStore('translations', {
 
           return true
         } else {
-          if (import.meta.client) {
-            alert('添加语言失败')
-          }
           return false
         }
       } catch (error) {
         console.error('Error adding language:', error)
         const errorMessage = error instanceof Error ? error.message : String(error)
-        if (import.meta.client) {
-          alert(`添加语言失败: ${errorMessage}`)
-        }
+        const dialog = getDialog()
+        await dialog?.alert(`Failed to add language: ${errorMessage}`, { title: 'Operation failed' })
         return false
       }
     },
@@ -378,7 +473,20 @@ export const useTranslationsStore = defineStore('translations', {
         const response =
           await $fetch<ApiResponse<{ languages: Language[]; count: number }>>('/api/languages')
         if (response.success && response.data) {
-          this.availableLanguages = response.data.languages
+          const previousLanguages = new Map(
+            this.availableLanguages.map((lang) => [lang.code, lang])
+          )
+
+          this.availableLanguages = response.data.languages.map((lang) => {
+            const existing = previousLanguages.get(lang.code)
+            if (existing) {
+              return {
+                ...lang,
+                name: existing.name || lang.name
+              }
+            }
+            return lang
+          })
 
           // 如果当前语言不在可用语言中，切换到基准语言
           const currentExists = this.availableLanguages.some(


### PR DESCRIPTION
## Summary
- implement a shared dialog composable with a GlobalDialog overlay so alerts, confirms, and prompts render in-app with consistent styling
- update translation store, editor workflow, and header language switcher to call the new dialog utilities and switch user-facing copy to English
- adjust supporting components and test page to remove native browser alerts while keeping feedback flows intact

## Testing
- pnpm -C packages/locales-web build

------
https://chatgpt.com/codex/tasks/task_e_68d11b1ec6c083218f87237d16bece5a